### PR TITLE
Corrected CNF ACQ_RATE value which should be expressed in days.

### DIFF
--- a/fdsn2nodes.py
+++ b/fdsn2nodes.py
@@ -182,7 +182,7 @@ class NodesCreator(object):
             cnf_file.write("END_DATE|NA\n")
         else:
             cnf_file.write("END_DATE|%s\n" % (station.termination_date.strftime("%Y-%m-%d")))
-        cnf_file.write("ACQ_RATE|%s\n" % (str(sample_rate)))
+        cnf_file.write("ACQ_RATE|1/%s\n" % (str(86400*sample_rate)))
         cnf_file.write("UTC_DATA|+0\n")
         cnf_file.write("LAST_DELAY|1/24\n")
         cnf_file.write("FILES_FEATURES|sensor\n")


### PR DESCRIPTION
Matlab time value units are days, so the sample rate should be expressed in days.
Thus a 1/100 sample rate translate into a 1/8640000 days sample rate.